### PR TITLE
Add --no-color option

### DIFF
--- a/cmd/ecrm/main.go
+++ b/cmd/ecrm/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/fujiwara/ecrm"
 	"github.com/fujiwara/logutils"
+	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli/v2"
 )
 
@@ -48,6 +49,16 @@ func main() {
 				Usage:   "Set log level (debug, info, notice, warn, error)",
 				EnvVars: []string{"ECRM_LOG_LEVEL"},
 			},
+			&cli.BoolFlag{
+				Name:    "no-color",
+				Value:   !isatty.IsTerminal(os.Stdout.Fd()),
+				Usage:   "Whether or not to color the output",
+				EnvVars: []string{"ECRM_NO_COLOR"},
+			},
+		},
+		Before: func(c *cli.Context) error {
+			color.NoColor = c.Bool("no-color")
+			return nil
 		},
 		Commands: []*cli.Command{
 			{
@@ -59,6 +70,7 @@ func main() {
 						c.String("config"),
 						ecrm.Option{
 							Repository: c.String("repository"),
+							NoColor:    c.Bool("no-color"),
 						},
 					)
 				},
@@ -83,6 +95,7 @@ func main() {
 							Delete:     true,
 							Force:      c.Bool("force"),
 							Repository: c.String("repository"),
+							NoColor:    c.Bool("no-color"),
 						},
 					)
 				},
@@ -118,6 +131,7 @@ func main() {
 						Delete:     subcommand == "delete",
 						Force:      subcommand == "delete", //If it works as bootstrap for a Lambda function, delete images without confirmation.
 						Repository: os.Getenv("ECRM_REPOSITORY"),
+						NoColor:    c.Bool("no-color"),
 					},
 				)
 			})

--- a/ecrm.go
+++ b/ecrm.go
@@ -46,6 +46,7 @@ type Option struct {
 	Delete     bool
 	Force      bool
 	Repository string
+	NoColor    bool
 }
 
 func New(ctx context.Context, region string) (*App, error) {
@@ -193,7 +194,7 @@ func (app *App) scanRepositories(rcs []*RepositoryConfig, images map[string]set,
 	sort.SliceStable(sums, func(i, j int) bool {
 		return sums[i].repo < sums[j].repo
 	})
-	sums.print(os.Stdout)
+	sums.print(os.Stdout, opt.NoColor)
 	return idsMaps, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/goccy/go-yaml v1.9.4
 	github.com/k1LoW/duration v1.1.0
 	github.com/mattn/go-colorable v0.1.11 // indirect
+	github.com/mattn/go-isatty v0.0.14
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/sys v0.0.0-20211015200801-69063c4bb744 // indirect

--- a/summary.go
+++ b/summary.go
@@ -28,7 +28,7 @@ func (s *summary) row() []string {
 
 type summaries []*summary
 
-func (s *summaries) print(w io.Writer) {
+func (s *summaries) print(w io.Writer, noColor bool) {
 	t := tablewriter.NewWriter(w)
 	t.SetHeader(s.header())
 	t.SetBorder(false)
@@ -43,7 +43,11 @@ func (s *summaries) print(w io.Writer) {
 		if strings.HasPrefix(row[3], "0 ") {
 			colors[3] = tablewriter.Colors{tablewriter.FgYellowColor}
 		}
-		t.Rich(row, colors)
+		if noColor {
+			t.Append(row)
+		} else {
+			t.Rich(row, colors)
+		}
 	}
 	t.Render()
 }


### PR DESCRIPTION
When executed in a Lambda function, the color code is output in the CloudWatch Logs output and becomes difficult to read.

Therefore, we will send a PR to add a NoColor option.
The default value for this NoColor option is to check the tty to see if it is terminal. If it is a terminal, the default is false, otherwise it is true.