### PR TITLE
feat: add JSON output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ OPTIONS:
 ```console
 $ ecrm plan --help
 NAME:
-   ecrm plan - scan ECS resources and find unused ECR images to delete safety.
+   ecrm plan - Scan ECS/Lambda resources and find unused ECR images to delete safety.
 
 USAGE:
    ecrm plan [command options] [arguments...]
 
 OPTIONS:
+   --format value                          plan output format (table, json) (default: table)
    --repository REPOSITORY, -r REPOSITORY  plan for only images in REPOSITORY [$ECRM_REPOSITORY]
-   --help, -h                              show help (default: false)
 ```
 
 `ecrm plan` shows summaries of unused images in ECR.

--- a/cli.go
+++ b/cli.go
@@ -47,7 +47,7 @@ func (app *App) NewPlanCommand() *cli.Command {
 			&cli.StringFlag{
 				Name:        "format",
 				DefaultText: "table",
-				Usage:       "plan output format (table)",
+				Usage:       "plan output format (table, json)",
 			},
 		},
 		Action: func(c *cli.Context) error {

--- a/cli.go
+++ b/cli.go
@@ -51,13 +51,17 @@ func (app *App) NewPlanCommand() *cli.Command {
 			},
 		},
 		Action: func(c *cli.Context) error {
+			format, err := newOutputFormatFrom(c.String("format"))
+			if err != nil {
+				return err
+			}
 			return app.Run(
 				c.Context,
 				c.String("config"),
 				Option{
 					Repository: c.String("repository"),
 					NoColor:    c.Bool("no-color"),
-					Format:     newOutputFormatFrom(c.String("format")),
+					Format:     format,
 				},
 			)
 		},

--- a/cli.go
+++ b/cli.go
@@ -44,6 +44,11 @@ func (app *App) NewPlanCommand() *cli.Command {
 				Usage:       "plan for only images in `REPOSITORY`",
 				EnvVars:     []string{"ECRM_REPOSITORY"},
 			},
+			&cli.StringFlag{
+				Name:        "format",
+				DefaultText: "table",
+				Usage:       "plan output format (table)",
+			},
 		},
 		Action: func(c *cli.Context) error {
 			return app.Run(
@@ -52,6 +57,7 @@ func (app *App) NewPlanCommand() *cli.Command {
 				Option{
 					Repository: c.String("repository"),
 					NoColor:    c.Bool("no-color"),
+					Format:     newOutputFormatFrom(c.String("format")),
 				},
 			)
 		},

--- a/ecrm.go
+++ b/ecrm.go
@@ -204,7 +204,7 @@ func (app *App) scanRepositories(ctx context.Context, rcs []*RepositoryConfig, i
 		}
 	}
 	sort.SliceStable(sums, func(i, j int) bool {
-		return sums[i].repo < sums[j].repo
+		return sums[i].Repo < sums[j].Repo
 	})
 	if err := sums.print(os.Stdout, opt.NoColor, opt.Format); err != nil {
 		return nil, err
@@ -252,11 +252,11 @@ func (app *App) DeleteImages(ctx context.Context, repo string, ids []ecrTypes.Im
 
 func (app *App) unusedImageIdentifiers(ctx context.Context, name string, rc *RepositoryConfig, holdImages map[string]set) ([]ecrTypes.ImageIdentifier, *summary, error) {
 	sum := &summary{
-		repo:             name,
-		totalImages:      0,
-		expiredImages:    0,
-		totalImageSize:   0,
-		expiredImageSize: 0,
+		Repo:             name,
+		TotalImages:      0,
+		ExpiredImages:    0,
+		TotalImageSize:   0,
+		ExpiredImageSize: 0,
 	}
 	p := ecr.NewDescribeImagesPaginator(app.ecr, &ecr.DescribeImagesInput{
 		RepositoryName: &name,
@@ -278,8 +278,8 @@ func (app *App) unusedImageIdentifiers(ctx context.Context, name string, rc *Rep
 IMAGE:
 	for _, d := range details {
 		hold := false
-		sum.totalImages++
-		sum.totalImageSize += aws.ToInt64(d.ImageSizeInBytes)
+		sum.TotalImages++
+		sum.TotalImageSize += aws.ToInt64(d.ImageSizeInBytes)
 	TAG:
 		for _, tag := range d.ImageTags {
 			if rc.MatchTag(tag) {
@@ -311,8 +311,8 @@ IMAGE:
 		}
 		log.Printf("[notice] %s is expired %s %s", displayName, *d.ImageDigest, pushedAt.Format(time.RFC3339))
 		ids = append(ids, ecrTypes.ImageIdentifier{ImageDigest: d.ImageDigest})
-		sum.expiredImages++
-		sum.expiredImageSize += aws.ToInt64(d.ImageSizeInBytes)
+		sum.ExpiredImages++
+		sum.ExpiredImageSize += aws.ToInt64(d.ImageSizeInBytes)
 	}
 	return ids, sum, nil
 }

--- a/ecrm.go
+++ b/ecrm.go
@@ -46,6 +46,7 @@ type Option struct {
 	Force      bool
 	Repository string
 	NoColor    bool
+	Format     outputFormat
 }
 
 func New(ctx context.Context, region string) (*App, error) {
@@ -205,7 +206,9 @@ func (app *App) scanRepositories(ctx context.Context, rcs []*RepositoryConfig, i
 	sort.SliceStable(sums, func(i, j int) bool {
 		return sums[i].repo < sums[j].repo
 	})
-	sums.print(os.Stdout, opt.NoColor)
+	if err := sums.print(os.Stdout, opt.NoColor, opt.Format); err != nil {
+		return nil, err
+	}
 	return idsMaps, nil
 }
 

--- a/summary.go
+++ b/summary.go
@@ -27,14 +27,14 @@ func (s *summary) row() []string {
 	}
 }
 
-func newOutputFormatFrom(s string) outputFormat {
+func newOutputFormatFrom(s string) (outputFormat, error) {
 	switch s {
 	case "table":
-		return formatTable
+		return formatTable, nil
 	case "json":
-		return formatJSON
+		return formatJSON, nil
 	default:
-		return formatInvalid
+		return outputFormat(0), fmt.Errorf("invalid format name: %s", s)
 	}
 }
 
@@ -52,8 +52,7 @@ func (f outputFormat) String() string {
 }
 
 const (
-	formatInvalid outputFormat = iota
-	formatTable
+	formatTable outputFormat = iota + 1
 	formatJSON
 )
 

--- a/summary.go
+++ b/summary.go
@@ -1,6 +1,7 @@
 package ecrm
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -30,6 +31,8 @@ func newOutputFormatFrom(s string) outputFormat {
 	switch s {
 	case "table":
 		return formatTable
+	case "json":
+		return formatJSON
 	default:
 		return formatInvalid
 	}
@@ -41,6 +44,8 @@ func (f outputFormat) String() string {
 	switch f {
 	case formatTable:
 		return "table"
+	case formatJSON:
+		return "json"
 	default:
 		return "unknown"
 	}
@@ -49,6 +54,7 @@ func (f outputFormat) String() string {
 const (
 	formatInvalid outputFormat = iota
 	formatTable
+	formatJSON
 )
 
 type summaries []*summary
@@ -57,9 +63,17 @@ func (s *summaries) print(w io.Writer, noColor bool, format outputFormat) error 
 	switch format {
 	case formatTable:
 		return s.printTable(w, noColor)
+	case formatJSON:
+		return s.printJSON(w)
 	default:
 		return fmt.Errorf("unknown output format: %s", format)
 	}
+}
+
+func (s *summaries) printJSON(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(s)
 }
 
 func (s *summaries) printTable(w io.Writer, noColor bool) error {

--- a/summary.go
+++ b/summary.go
@@ -10,19 +10,19 @@ import (
 )
 
 type summary struct {
-	repo             string
-	expiredImages    int64
-	totalImages      int64
-	expiredImageSize int64
-	totalImageSize   int64
+	Repo             string
+	ExpiredImages    int64
+	TotalImages      int64
+	ExpiredImageSize int64
+	TotalImageSize   int64
 }
 
 func (s *summary) row() []string {
 	return []string{
-		s.repo,
-		fmt.Sprintf("%d (%s)", s.totalImages, humanize.Bytes(uint64(s.totalImageSize))),
-		fmt.Sprintf("%d (%s)", -s.expiredImages, humanize.Bytes(uint64(s.expiredImageSize))),
-		fmt.Sprintf("%d (%s)", s.totalImages-s.expiredImages, humanize.Bytes(uint64(s.totalImageSize-s.expiredImageSize))),
+		s.Repo,
+		fmt.Sprintf("%d (%s)", s.TotalImages, humanize.Bytes(uint64(s.TotalImageSize))),
+		fmt.Sprintf("%d (%s)", -s.ExpiredImages, humanize.Bytes(uint64(s.ExpiredImageSize))),
+		fmt.Sprintf("%d (%s)", s.TotalImages-s.ExpiredImages, humanize.Bytes(uint64(s.TotalImageSize-s.ExpiredImageSize))),
 	}
 }
 

--- a/summary.go
+++ b/summary.go
@@ -11,11 +11,11 @@ import (
 )
 
 type summary struct {
-	Repo             string
-	ExpiredImages    int64
-	TotalImages      int64
-	ExpiredImageSize int64
-	TotalImageSize   int64
+	Repo             string `json:"repository"`
+	ExpiredImages    int64  `json:"expired_images"`
+	TotalImages      int64  `json:"total_images"`
+	ExpiredImageSize int64  `json:"expired_image_size"`
+	TotalImageSize   int64  `json:"total_image_size"`
 }
 
 func (s *summary) row() []string {

--- a/summary.go
+++ b/summary.go
@@ -26,9 +26,43 @@ func (s *summary) row() []string {
 	}
 }
 
+func newOutputFormatFrom(s string) outputFormat {
+	switch s {
+	case "table":
+		return formatTable
+	default:
+		return formatInvalid
+	}
+}
+
+type outputFormat int
+
+func (f outputFormat) String() string {
+	switch f {
+	case formatTable:
+		return "table"
+	default:
+		return "unknown"
+	}
+}
+
+const (
+	formatInvalid outputFormat = iota
+	formatTable
+)
+
 type summaries []*summary
 
-func (s *summaries) print(w io.Writer, noColor bool) {
+func (s *summaries) print(w io.Writer, noColor bool, format outputFormat) error {
+	switch format {
+	case formatTable:
+		return s.printTable(w, noColor)
+	default:
+		return fmt.Errorf("unknown output format: %s", format)
+	}
+}
+
+func (s *summaries) printTable(w io.Writer, noColor bool) error {
 	t := tablewriter.NewWriter(w)
 	t.SetHeader(s.header())
 	t.SetBorder(false)
@@ -50,6 +84,7 @@ func (s *summaries) print(w io.Writer, noColor bool) {
 		}
 	}
 	t.Render()
+	return nil
 }
 
 func (s *summaries) header() []string {


### PR DESCRIPTION
- now `ecrm plan` takes new `-format` option that indicates plan's output format
  - default value is `table` which is current ASCII table format
- `-format` also takes `json` that is formatted as JSON
- JSON format is programmable
  - We can use [jq](https://stedolan.github.io/jq/) or something like to manipulate `ecrm plan`'s output