### PR TITLE
Add exclude_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ repositories:
       - latest
   - name_pattern: "dev/*"
     expires: 30days
+exclude_files:
+  - exclude.txt
 ```
 
 ### generate command
@@ -116,6 +118,25 @@ OPTIONS:
    --force                                 force delete images without confirmation (default: false) [$ECRM_FORCE]
    --repository REPOSITORY, -r REPOSITORY  delete only images in REPOSITORY [$ECRM_REPOSITORY]
    --help, -h                              show help (default: false)
+```
+
+### exclude_files
+
+ecrm reads `exclude_files` in config from local files.
+
+```yaml
+exclude_files:
+  - path/to/exclude.txt
+```
+
+Exclude file is a text file includes ECR image URL lines delimitered by LF.
+These images are not deleted by `ecrm delete`.
+
+```txt
+# this is a comment
+0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/xxx/yyy:foo
+0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/xxx/yyy:bar
+# 0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/xxx/yyy:baz  # ignored
 ```
 
 ## Author

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ exclude_files:
   - path/to/exclude.txt
 ```
 
-Exclude file is a text file includes ECR image URL lines delimitered by LF.
+Exclude file is a plan text file that includes ECR image URL lines delimited by LF.
 These images are not deleted by `ecrm delete`.
 
 ```txt

--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ var (
 )
 
 type Config struct {
+	ExcludeFiles    []string            `yaml:"exclude_files"`
 	Clusters        []*ClusterConfig    `yaml:"clusters"`
 	TaskDefinitions []*TaskdefConfig    `yaml:"task_definitions"`
 	LambdaFunctions []*LambdaConfig     `yaml:"lambda_functions"`
@@ -56,6 +57,12 @@ func (c *Config) Validate() error {
 	for _, rc := range c.Repositories {
 		if err := rc.Validate(); err != nil {
 			return err
+		}
+	}
+
+	for _, ex := range c.ExcludeFiles {
+		if _, err := os.Stat(ex); err != nil {
+			return fmt.Errorf("exclude_files: %s: %w", ex, err)
 		}
 	}
 	return nil

--- a/ecrm.go
+++ b/ecrm.go
@@ -116,6 +116,10 @@ func (app *App) Run(ctx context.Context, path string, opt Option) error {
 		return err
 	}
 
+	if err = app.readExcludeFiles(ctx, c.ExcludeFiles, images); err != nil {
+		return err
+	}
+
 	idsMaps, err := app.scanRepositories(ctx, c.Repositories, images, opt)
 	if err != nil {
 		return err

--- a/ecrm.yaml
+++ b/ecrm.yaml
@@ -11,3 +11,5 @@ repositories:
     expires: 30 days
     keep_tag_patterns:
       - latest
+exclude_files:
+  - my_exclude_file.txt

--- a/ecrm.yaml
+++ b/ecrm.yaml
@@ -12,4 +12,4 @@ repositories:
     keep_tag_patterns:
       - latest
 exclude_files:
-  - my_exclude_file.txt
+  - testdata/my_exclude_file.txt

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,9 @@
+package ecrm
+
+var (
+	ReadExcludeFile = readExcludeFile
+)
+
+func NewImagesSet() map[string]set {
+	return make(map[string]set)
+}

--- a/file.go
+++ b/file.go
@@ -11,14 +11,14 @@ import (
 func (app *App) readExcludeFiles(ctx context.Context, paths []string, images map[string]set) error {
 	for _, path := range paths {
 		log.Println("[info] reading exclude file", path)
-		if err := app.readExcludeFile(ctx, path, images); err != nil {
+		if err := readExcludeFile(ctx, path, images); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (app *App) readExcludeFile(ctx context.Context, path string, images map[string]set) error {
+func readExcludeFile(ctx context.Context, path string, images map[string]set) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return err
@@ -28,7 +28,7 @@ func (app *App) readExcludeFile(ctx context.Context, path string, images map[str
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		img := scanner.Text()
-		if strings.HasPrefix(img, "#") {
+		if strings.HasPrefix(img, "#") || img == "" {
 			continue
 		}
 		if !strings.Contains(img, ".dkr.ecr.") {

--- a/file.go
+++ b/file.go
@@ -1,0 +1,48 @@
+package ecrm
+
+import (
+	"bufio"
+	"context"
+	"log"
+	"os"
+	"strings"
+)
+
+func (app *App) readExcludeFiles(ctx context.Context, paths []string, images map[string]set) error {
+	for _, path := range paths {
+		log.Println("[info] reading exclude file", path)
+		if err := app.readExcludeFile(ctx, path, images); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (app *App) readExcludeFile(ctx context.Context, path string, images map[string]set) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		img := scanner.Text()
+		if strings.HasPrefix(img, "#") {
+			continue
+		}
+		if !strings.Contains(img, ".dkr.ecr.") {
+			log.Println("[warn] skipping line", img)
+			continue
+		}
+		if images[img] == nil {
+			images[img] = newSet()
+		}
+		log.Printf("[info] %s is defined in %s", img, path)
+		images[img].add(path)
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/file_test.go
+++ b/file_test.go
@@ -1,0 +1,27 @@
+package ecrm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fujiwara/ecrm"
+)
+
+func TestReadExcludeFile(t *testing.T) {
+	images := ecrm.NewImagesSet()
+	err := ecrm.ReadExcludeFile(context.Background(), "testdata/my_exclude_file.txt", images)
+	if err != nil {
+		t.Error("failed to ReadExcludeFile", err)
+	}
+	if len(images) != 2 {
+		t.Error("failed to ReadExcludeFile")
+	}
+	for _, img := range []string{
+		"0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/xxx/yyy:foo",
+		"0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/xxx/yyy:bar",
+	} {
+		if _, ok := images[img]; !ok {
+			t.Error("img not found", img)
+		}
+	}
+}

--- a/my_exclude_file.txt
+++ b/my_exclude_file.txt
@@ -1,6 +1,0 @@
-# this is comment
-314472643515.dkr.ecr.ap-northeast-1.amazonaws.com/xxx/yyy:latest
-hoge
-314472643515.dkr.ecr.ap-northeast-1.amazonaws.com/hub/fujiwara/maprobe:v0.3.5-bullseye-slim
-314472643515.dkr.ecr.ap-northeast-1.amazonaws.com/hub/fujiwara/maprobe:v0.3.5-mackerel-plugins
-# 314472643515.dkr.ecr.ap-northeast-1.amazonaws.com/hub/fujiwara/maprobe:v0.3.5-plain

--- a/my_exclude_file.txt
+++ b/my_exclude_file.txt
@@ -1,0 +1,6 @@
+# this is comment
+314472643515.dkr.ecr.ap-northeast-1.amazonaws.com/xxx/yyy:latest
+hoge
+314472643515.dkr.ecr.ap-northeast-1.amazonaws.com/hub/fujiwara/maprobe:v0.3.5-bullseye-slim
+314472643515.dkr.ecr.ap-northeast-1.amazonaws.com/hub/fujiwara/maprobe:v0.3.5-mackerel-plugins
+# 314472643515.dkr.ecr.ap-northeast-1.amazonaws.com/hub/fujiwara/maprobe:v0.3.5-plain

--- a/testdata/my_exclude_file.txt
+++ b/testdata/my_exclude_file.txt
@@ -1,0 +1,5 @@
+# this is a comment
+0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/xxx/yyy:foo
+0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/xxx/yyy:bar
+
+# 0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/xxx/yyy:baz  # ignored


### PR DESCRIPTION
ecrm reads `exclude_files` in config from local files.

```yaml
exclude_files:
  - path/to/exclude.txt
```

Exclude file is a text file that includes ECR image URL lines delimited by LF.
These images are not deleted by `ecrm delete`.

```txt
# this is a comment
0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/xxx/yyy:foo
0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/xxx/yyy:bar
# 0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/xxx/yyy:baz  # ignored
```
