### PR TITLE
Hold images identified by digest.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # vendor/
 
 .envrc
+./ecrm

--- a/config.go
+++ b/config.go
@@ -81,12 +81,14 @@ func (c *ClusterConfig) Match(name string) bool {
 	return wildcard.Match(c.NamePattern, name)
 }
 
+type RepositoryName string
+
 type RepositoryConfig struct {
-	Name            string   `yaml:"name,omitempty"`
-	NamePattern     string   `yaml:"name_pattern,omitempty"`
-	Expires         string   `yaml:"expires,omitempty"`
-	KeepCount       int64    `yaml:"keep_count,omitempty"`
-	KeepTagPatterns []string `yaml:"keep_tag_patterns,omitempty"`
+	Name            RepositoryName `yaml:"name,omitempty"`
+	NamePattern     string         `yaml:"name_pattern,omitempty"`
+	Expires         string         `yaml:"expires,omitempty"`
+	KeepCount       int64          `yaml:"keep_count,omitempty"`
+	KeepTagPatterns []string       `yaml:"keep_tag_patterns,omitempty"`
 
 	expireBefore time.Time
 }
@@ -117,11 +119,11 @@ func (r *RepositoryConfig) Validate() error {
 	return nil
 }
 
-func (r *RepositoryConfig) MatchName(name string) bool {
+func (r *RepositoryConfig) MatchName(name RepositoryName) bool {
 	if r.Name == name {
 		return true
 	}
-	return wildcard.Match(r.NamePattern, name)
+	return wildcard.Match(r.NamePattern, string(name))
 }
 
 func (r *RepositoryConfig) MatchTag(tag string) bool {

--- a/ecrm.go
+++ b/ecrm.go
@@ -473,12 +473,12 @@ func (app *App) scanClusters(ctx context.Context, clustersConfigs []*ClusterConf
 
 func (app *App) scanTaskdefs(ctx context.Context, tcs []*TaskdefConfig) ([]taskdef, error) {
 	tds := make([]taskdef, 0)
-	famiries, err := app.taskDefinitionFamilies(ctx)
+	families, err := app.taskDefinitionFamilies(ctx)
 	if err != nil {
 		return tds, err
 	}
 
-	for _, family := range famiries {
+	for _, family := range families {
 		var name string
 		var keepCount int64
 		for _, tc := range tcs {

--- a/ecrm.go
+++ b/ecrm.go
@@ -269,6 +269,21 @@ IMAGE:
 		displayName := string(repo) + ":" + tag
 		sums.Add(d)
 
+		// Check if the image is expired
+		pushedAt := *d.ImagePushedAt
+		if !rc.IsExpired(pushedAt) {
+			log.Printf("[info] image %s is not expired, keep it", displayName)
+			continue IMAGE
+		}
+
+		if tagged {
+			keepCount++
+			if keepCount <= rc.KeepCount {
+				log.Printf("[info] image %s is in keep_count %d <= %d, keep it", displayName, keepCount, rc.KeepCount)
+				continue IMAGE
+			}
+		}
+
 		// Check if the image is in use (digest)
 		imageURISha256 := ImageURI(fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s@%s", *d.RegistryId, app.region, *d.RepositoryName, *d.ImageDigest))
 		log.Printf("[debug] checking %s", imageURISha256)
@@ -287,19 +302,6 @@ IMAGE:
 			log.Printf("[debug] checking %s", imageURI)
 			if holdImages.Contains(imageURI) {
 				log.Printf("[info] image %s:%s is in used, keep it", repo, tag)
-				continue IMAGE
-			}
-		}
-
-		pushedAt := *d.ImagePushedAt
-		if !rc.IsExpired(pushedAt) {
-			log.Printf("[info] image %s is not expired, keep it", displayName)
-			continue IMAGE
-		}
-		if tagged {
-			keepCount++
-			if keepCount <= rc.KeepCount {
-				log.Printf("[info] image %s is in keep_count %d <= %d, keep it", displayName, keepCount, rc.KeepCount)
 				continue IMAGE
 			}
 		}

--- a/ecrm.go
+++ b/ecrm.go
@@ -186,8 +186,9 @@ func (app *App) aggregateECRImages(ctx context.Context, taskdefs []taskdef) (Ima
 			return nil, err
 		}
 		for _, id := range ids {
-			log.Printf("[info] %s is in use by task definition %s", id.Short(), tds)
-			images.Add(id, tds)
+			if images.Add(id, tds) {
+				log.Printf("[info] %s is in use by task definition %s", id.Short(), tds)
+			}
 		}
 	}
 	return images, nil
@@ -595,14 +596,16 @@ func (app *App) availableResourcesInCluster(ctx context.Context, clusterArn stri
 				}
 				// ECR image
 				if u.IsDigestURI() {
-					log.Printf("[info] %s is used by %s container on %s/%s", u.Short(), *c.Name, *task.TaskArn, clusterName)
-					images.Add(u, tdArn)
+					if images.Add(u, tdArn) {
+						log.Printf("[info] %s is used by %s container on %s", u.Short(), *c.Name, *task.TaskArn)
+					}
 				} else {
 					base := u.Base()
 					digest := aws.ToString(c.ImageDigest)
 					u := ImageURI(base + "@" + digest)
-					log.Printf("[info] %s is used by %s container on %s/%s", u.Short(), *c.Name, *task.TaskArn, clusterName)
-					images.Add(u, tdArn)
+					if images.Add(u, tdArn) {
+						log.Printf("[info] %s is used by %s container on %s", u.Short(), *c.Name, *task.TaskArn)
+					}
 				}
 			}
 		}

--- a/ecrm.go
+++ b/ecrm.go
@@ -52,6 +52,32 @@ func (td taskdef) String() string {
 	return fmt.Sprintf("%s:%d", td.name, td.revision)
 }
 
+func parseTaskdefArn(s string) (taskdef, error) {
+	a, err := arn.Parse(s)
+	if err != nil {
+		return taskdef{}, err
+	}
+	if a.Service != "ecs" {
+		return taskdef{}, errors.New("not an ECS task definition ARN")
+	}
+	p := strings.SplitN(a.Resource, "/", 2)
+	if len(p) != 2 {
+		return taskdef{}, errors.New("invalid task definition ARN")
+	}
+	if p[0] != "task-definition" {
+		return taskdef{}, errors.New("not a task definition ARN")
+	}
+	nr := strings.SplitN(p[1], ":", 2)
+	if len(nr) != 2 {
+		return taskdef{}, errors.New("invalid task definition name")
+	}
+	rev, err := strconv.Atoi(nr[1])
+	if err != nil {
+		return taskdef{}, err
+	}
+	return taskdef{name: nr[0], revision: rev}, nil
+}
+
 type Option struct {
 	Delete     bool
 	Force      bool

--- a/ecrm_test.go
+++ b/ecrm_test.go
@@ -1,0 +1,18 @@
+package ecrm_test
+
+import (
+	"testing"
+
+	"github.com/fujiwara/ecrm"
+)
+
+func TestParseTaskDefArn(t *testing.T) {
+	arn := "arn:aws:ecs:ap-northeast-1:0123456789012:task-definition/ecspresso-test:884"
+	td, err := ecrm.ParseTaskdefArn(arn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if td.String() != "ecspresso-test:884" {
+		t.Errorf("unexpected task definition: %s", td)
+	}
+}

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,5 @@
+package ecrm
+
+var (
+	ParseTaskdefArn = parseTaskdefArn
+)

--- a/images.go
+++ b/images.go
@@ -1,0 +1,33 @@
+package ecrm
+
+import "strings"
+
+// ImageID is a type of ID of an ECR image.
+type ImageID string
+
+func (id ImageID) String() string {
+	return string(id)
+}
+
+func (id ImageID) Short() string {
+	return strings.SplitN(string(id), "/", 2)[1]
+}
+
+type Images map[ImageID]set
+
+func (i Images) Add(id ImageID, usedBy string) bool {
+	if _, ok := i[id]; !ok {
+		i[id] = newSet()
+	}
+	return i[id].add(usedBy)
+}
+
+func (i Images) Contains(id ImageID) bool {
+	return !i[id].isEmpty()
+}
+
+func (i Images) Merge(j Images) {
+	for k, v := range j {
+		i[k] = i[k].union(v)
+	}
+}

--- a/images_test.go
+++ b/images_test.go
@@ -1,0 +1,48 @@
+package ecrm_test
+
+import (
+	"testing"
+
+	"github.com/fujiwara/ecrm"
+)
+
+func TestImageID(t *testing.T) {
+	id := ecrm.ImageID("0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar:fe668fb9")
+	if id.String() != "0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar:fe668fb9" {
+		t.Errorf("unexpected image id: %s", id)
+	}
+	if id.Short() != "foo/bar:fe668fb9" {
+		t.Errorf("unexpected short image id: %s", id)
+	}
+}
+
+func TestImages(t *testing.T) {
+	images := make(ecrm.Images)
+
+	if images.Contains("foo") {
+		t.Error("unexpected contains")
+	}
+	images.Add("foo", "bar")
+	if !images.Contains("foo") {
+		t.Error("unexpected not contains")
+	}
+	if images.Contains("bar") {
+		t.Error("unexpected contains")
+	}
+	images.Add("foo", "baz")
+	if !images.Contains("foo") {
+		t.Error("unexpected not contains")
+	}
+
+	j := make(ecrm.Images)
+	j.Add("foo", "qux")
+	j.Add("bar", "qux")
+	j.Add("baz", "qux")
+	images.Merge(j)
+	for _, v := range []ecrm.ImageID{"foo", "bar", "baz"} {
+		if !images.Contains(v) {
+			t.Errorf("unexpected not contains: %s", v)
+		}
+	}
+	t.Logf("images: %#v", images)
+}

--- a/images_test.go
+++ b/images_test.go
@@ -6,13 +6,41 @@ import (
 	"github.com/fujiwara/ecrm"
 )
 
-func TestImageID(t *testing.T) {
-	id := ecrm.ImageID("0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar:fe668fb9")
-	if id.String() != "0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar:fe668fb9" {
-		t.Errorf("unexpected image id: %s", id)
+func TestImageURI(t *testing.T) {
+	u := ecrm.ImageURI("0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar:fe668fb9")
+	if u.String() != "0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar:fe668fb9" {
+		t.Errorf("unexpected image uri: %s", u)
 	}
-	if id.Short() != "foo/bar:fe668fb9" {
-		t.Errorf("unexpected short image id: %s", id)
+	if u.Short() != "foo/bar:fe668fb9" {
+		t.Errorf("unexpected short image uri: %s", u)
+	}
+	if u.Base() != "0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar" {
+		t.Errorf("unexpected base image uri: %s", u)
+	}
+	if u.Tag() != "fe668fb9" {
+		t.Errorf("unexpected tag image uri: %s", u)
+	}
+	if u.IsDigestURI() {
+		t.Errorf("unexpected digest uri: %s", u)
+	}
+}
+
+func TestImageURIDigest(t *testing.T) {
+	u := ecrm.ImageURI("0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar@sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c")
+	if u.String() != "0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar@sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c" {
+		t.Errorf("unexpected image uri: %s", u)
+	}
+	if u.Short() != "foo/bar@sha256:b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c" {
+		t.Errorf("unexpected short image uri: %s", u)
+	}
+	if u.Base() != "0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar" {
+		t.Errorf("unexpected base image uri: %s", u)
+	}
+	if u.Tag() != "" {
+		t.Errorf("unexpected tag image uri: %s", u)
+	}
+	if !u.IsDigestURI() {
+		t.Errorf("unexpected not digest uri: %s", u)
 	}
 }
 
@@ -39,7 +67,7 @@ func TestImages(t *testing.T) {
 	j.Add("bar", "qux")
 	j.Add("baz", "qux")
 	images.Merge(j)
-	for _, v := range []ecrm.ImageID{"foo", "bar", "baz"} {
+	for _, v := range []ecrm.ImageURI{"foo", "bar", "baz"} {
 		if !images.Contains(v) {
 			t.Errorf("unexpected not contains: %s", v)
 		}

--- a/lambda.go
+++ b/lambda.go
@@ -87,8 +87,9 @@ func (app *App) scanLambdaFunctions(ctx context.Context, lcs []*LambdaConfig) (I
 				continue
 			}
 			log.Println("[debug] ImageUri", u)
-			images.Add(u, aws.ToString(v.FunctionArn))
-			log.Printf("[info] %s is in use by Lambda function %s:%s", u.Short(), *v.FunctionName, *v.Version)
+			if images.Add(u, aws.ToString(v.FunctionArn)) {
+				log.Printf("[info] %s is in use by Lambda function %s:%s", u.Short(), *v.FunctionName, *v.Version)
+			}
 		}
 	}
 	return images, nil

--- a/lambda.go
+++ b/lambda.go
@@ -31,7 +31,7 @@ func (app *App) lambdaFunctions(ctx context.Context) ([]lambdaTypes.FunctionConf
 	return fns, nil
 }
 
-func (app *App) scanLambdaFunctions(ctx context.Context, lcs []*LambdaConfig, images map[string]set) error {
+func (app *App) scanLambdaFunctions(ctx context.Context, lcs []*LambdaConfig, images map[ImageID]set) error {
 	funcs, err := app.lambdaFunctions(ctx)
 	if err != nil {
 		return err
@@ -41,9 +41,9 @@ func (app *App) scanLambdaFunctions(ctx context.Context, lcs []*LambdaConfig, im
 		var name string
 		var keepCount int64
 		for _, tc := range lcs {
-			fname := *fn.FunctionName
-			if tc.Match(fname) {
-				name = fname
+			fn := *fn.FunctionName
+			if tc.Match(fn) {
+				name = fn
 				keepCount = tc.KeepCount
 				break
 			}
@@ -81,7 +81,7 @@ func (app *App) scanLambdaFunctions(ctx context.Context, lcs []*LambdaConfig, im
 			if err != nil {
 				return err
 			}
-			img := aws.ToString(f.Code.ImageUri)
+			img := ImageID(aws.ToString(f.Code.ImageUri))
 			if img == "" {
 				continue
 			}

--- a/lambda.go
+++ b/lambda.go
@@ -82,13 +82,13 @@ func (app *App) scanLambdaFunctions(ctx context.Context, lcs []*LambdaConfig) (I
 			if err != nil {
 				return nil, err
 			}
-			id := ImageID(aws.ToString(f.Code.ImageUri))
-			if id == "" {
+			u := ImageURI(aws.ToString(f.Code.ImageUri))
+			if u == "" {
 				continue
 			}
-			log.Println("[debug] ImageUri", id)
-			images.Add(id, aws.ToString(v.FunctionArn))
-			log.Printf("[info] %s is in use by Lambda function %s:%s", id.Short(), *v.FunctionName, *v.Version)
+			log.Println("[debug] ImageUri", u)
+			images.Add(u, aws.ToString(v.FunctionArn))
+			log.Printf("[info] %s is in use by Lambda function %s:%s", u.Short(), *v.FunctionName, *v.Version)
 		}
 	}
 	return images, nil

--- a/set.go
+++ b/set.go
@@ -6,8 +6,17 @@ func newSet() set {
 	return make(map[string]struct{})
 }
 
-func (s set) add(v string) {
+func (s set) add(v string) bool {
+	if _, ok := s[v]; ok {
+		return true
+	}
 	s[v] = struct{}{}
+	return false
+}
+
+func (s set) contains(v string) bool {
+	_, ok := s[v]
+	return ok
 }
 
 func (s set) remove(v string) {
@@ -15,6 +24,9 @@ func (s set) remove(v string) {
 }
 
 func (s set) isEmpty() bool {
+	if s == nil {
+		return true
+	}
 	return len(s) == 0
 }
 
@@ -24,4 +36,18 @@ func (s set) members() []string {
 		members = append(members, k)
 	}
 	return members
+}
+
+func (s set) union(o set) set {
+	if o == nil {
+		return s
+	}
+	u := newSet()
+	for k := range s {
+		u.add(k)
+	}
+	for k := range o {
+		u.add(k)
+	}
+	return u
 }

--- a/summary.go
+++ b/summary.go
@@ -22,7 +22,7 @@ const (
 
 type RepoSummary []*Summary
 
-func NewRepoSummary(repo string) RepoSummary {
+func NewRepoSummary(repo RepositoryName) RepoSummary {
 	return []*Summary{
 		{Repo: repo, Type: SummaryTypeImage},
 		{Repo: repo, Type: SummaryTypeImageIndex},
@@ -63,12 +63,12 @@ func (s RepoSummary) Expire(img ecrTypes.ImageDetail) {
 }
 
 type Summary struct {
-	Repo             string `json:"repository"`
-	Type             string `json:"type"`
-	ExpiredImages    int64  `json:"expired_images"`
-	TotalImages      int64  `json:"total_images"`
-	ExpiredImageSize int64  `json:"expired_image_size"`
-	TotalImageSize   int64  `json:"total_image_size"`
+	Repo             RepositoryName `json:"repository"`
+	Type             string         `json:"type"`
+	ExpiredImages    int64          `json:"expired_images"`
+	TotalImages      int64          `json:"total_images"`
+	ExpiredImageSize int64          `json:"expired_image_size"`
+	TotalImageSize   int64          `json:"total_image_size"`
 }
 
 func (s *Summary) printable() bool {
@@ -80,7 +80,7 @@ func (s *Summary) printable() bool {
 
 func (s *Summary) row() []string {
 	return []string{
-		s.Repo,
+		string(s.Repo),
 		s.Type,
 		fmt.Sprintf("%d (%s)", s.TotalImages, humanize.Bytes(uint64(s.TotalImageSize))),
 		fmt.Sprintf("%d (%s)", -s.ExpiredImages, humanize.Bytes(uint64(s.ExpiredImageSize))),

--- a/task.go
+++ b/task.go
@@ -1,0 +1,45 @@
+package ecrm
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+)
+
+type taskdef struct {
+	name     string
+	revision int
+}
+
+func (td taskdef) String() string {
+	return fmt.Sprintf("%s:%d", td.name, td.revision)
+}
+
+func parseTaskdefArn(s string) (taskdef, error) {
+	a, err := arn.Parse(s)
+	if err != nil {
+		return taskdef{}, err
+	}
+	if a.Service != "ecs" {
+		return taskdef{}, errors.New("not an ECS task definition ARN")
+	}
+	p := strings.SplitN(a.Resource, "/", 2)
+	if len(p) != 2 {
+		return taskdef{}, errors.New("invalid task definition ARN")
+	}
+	if p[0] != "task-definition" {
+		return taskdef{}, errors.New("not a task definition ARN")
+	}
+	nr := strings.SplitN(p[1], ":", 2)
+	if len(nr) != 2 {
+		return taskdef{}, errors.New("invalid task definition name")
+	}
+	rev, err := strconv.Atoi(nr[1])
+	if err != nil {
+		return taskdef{}, err
+	}
+	return taskdef{name: nr[0], revision: rev}, nil
+}


### PR DESCRIPTION
Amazon ECS announced "software version consistency".
https://aws.amazon.com/jp/blogs/containers/announcing-software-version-consistency-for-amazon-ecs-services/

> Amazon ECS will now resolve a container image tag to its container image digest for every version ([deployment](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Deployment.html)) of an [Amazon ECS Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html). This ensures that the same container image is used throughout the lifecycle of the deployment, and increases both the security and consistency of your applications deployed as Amazon ECS services.

This means ecrm should hold ECR images identified by the image digest URI that is used by running ECS tasks.

This PR enables the detection of image digest URIs.