### PR TITLE
Fix hold order

### DIFF
--- a/ecrm.go
+++ b/ecrm.go
@@ -280,21 +280,6 @@ IMAGE:
 		displayName := string(repo) + ":" + tag
 		sums.Add(d)
 
-		// Check if the image is expired
-		pushedAt := *d.ImagePushedAt
-		if !rc.IsExpired(pushedAt) {
-			log.Printf("[info] image %s is not expired, keep it", displayName)
-			continue IMAGE
-		}
-
-		if tagged {
-			keepCount++
-			if keepCount <= rc.KeepCount {
-				log.Printf("[info] image %s is in keep_count %d <= %d, keep it", displayName, keepCount, rc.KeepCount)
-				continue IMAGE
-			}
-		}
-
 		// Check if the image is in use (digest)
 		imageURISha256 := ImageURI(fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s@%s", *d.RegistryId, app.region, *d.RepositoryName, *d.ImageDigest))
 		log.Printf("[debug] checking %s", imageURISha256)
@@ -313,6 +298,21 @@ IMAGE:
 			log.Printf("[debug] checking %s", imageURI)
 			if holdImages.Contains(imageURI) {
 				log.Printf("[info] image %s:%s is in used, keep it", repo, tag)
+				continue IMAGE
+			}
+		}
+
+		// Check if the image is expired
+		pushedAt := *d.ImagePushedAt
+		if !rc.IsExpired(pushedAt) {
+			log.Printf("[info] image %s is not expired, keep it", displayName)
+			continue IMAGE
+		}
+
+		if tagged {
+			keepCount++
+			if keepCount <= rc.KeepCount {
+				log.Printf("[info] image %s is in keep_count %d <= %d, keep it", displayName, keepCount, rc.KeepCount)
 				continue IMAGE
 			}
 		}

--- a/images_test.go
+++ b/images_test.go
@@ -61,6 +61,10 @@ func TestImages(t *testing.T) {
 	if !images.Contains("foo") {
 		t.Error("unexpected not contains")
 	}
+	if images.Add("foo", "baz") {
+		// already exists
+		t.Error("unexpected added")
+	}
 
 	j := make(ecrm.Images)
 	j.Add("foo", "qux")

--- a/set.go
+++ b/set.go
@@ -8,10 +8,10 @@ func newSet() set {
 
 func (s set) add(v string) bool {
 	if _, ok := s[v]; ok {
-		return true
+		return false // already exists
 	}
 	s[v] = struct{}{}
-	return false
+	return true // added
 }
 
 func (s set) contains(v string) bool {


### PR DESCRIPTION
#30 changed the order of detection holdings images unintentionally.
The images that are in use should be held at first.