### PR TITLE
feat: Support manifest list as Image Index of "Docker Image Manifest V2 Schema 2"

### DIFF
--- a/util.go
+++ b/util.go
@@ -18,6 +18,8 @@ func isImageIndex(d ecrTypes.ImageDetail) bool {
 	switch ociTypes.MediaType(aws.ToString(d.ImageManifestMediaType)) {
 	case ociTypes.OCIImageIndex:
 		return true
+	case ociTypes.DockerManifestList:
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
Thank you for developing such an amazing tool! It has been extremely useful for us.

In our organization, we use Docker to manage multi-architecture images, and thus, we utilize the [Image Manifest Version 2, Schema 2](https://matsuand.github.io/docs.docker.jp.onthefly/registry/spec/manifest-v2-2/)'s Manifest List (`application/vnd.docker.distribution.manifest.list.v2+json`) as our Image Index. Consequently, we have modified ecrm to recognize this as the Image Index.

Reference: [Container image manifest format support in Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-manifest-formats.html)