### PR TITLE
obsolete "keep_aliase". All aliased versions are always kept.

### DIFF
--- a/config.go
+++ b/config.go
@@ -110,7 +110,7 @@ func (r *RepositoryConfig) Validate() error {
 
 	if len(r.KeepTagPatterns) == 0 {
 		log.Printf(
-			"[warn] keep_tag_patterns are not defind. set default keep_tag_patterns to %v",
+			"[warn] keep_tag_patterns are not defined. set default keep_tag_patterns to %v",
 			DefaultKeepTagPatterns,
 		)
 		r.KeepTagPatterns = DefaultKeepTagPatterns
@@ -193,7 +193,7 @@ type LambdaConfig struct {
 	Name        string `yaml:"name,omitempty"`
 	NamePattern string `yaml:"name_pattern,omitempty"`
 	KeepCount   int64  `yaml:"keep_count,omitempty"`
-	KeepAliase  bool   `yaml:"keep_aliase,omitempty"`
+	KeepAliase  *bool  `yaml:"keep_aliase,omitempty"` // for backward compatibility
 }
 
 func (c *LambdaConfig) Validate() error {
@@ -208,6 +208,11 @@ func (c *LambdaConfig) Validate() error {
 			DefaultKeepCount,
 		)
 		c.KeepCount = int64(DefaultKeepCount)
+	}
+	if c.KeepAliase != nil {
+		log.Printf(
+			"[warn] \"keep_aliase\" is obsoleted. All aliased versions are always kept. Please remove it from the lambda_functions section.",
+		)
 	}
 	return nil
 }

--- a/generate.go
+++ b/generate.go
@@ -149,8 +149,7 @@ func (g *Generator) generateLambdaConfig(ctx context.Context, config *Config) er
 	}
 	for _, name := range lambdaNames.members() {
 		cfg := LambdaConfig{
-			KeepCount:  int64(DefaultKeepCount),
-			KeepAliase: true,
+			KeepCount:   int64(DefaultKeepCount),
 		}
 		if strings.Contains(name, "*") {
 			cfg.NamePattern = name

--- a/lambda.go
+++ b/lambda.go
@@ -65,7 +65,7 @@ func (s *Scanner) scanLambdaFunctions(ctx context.Context, lcs []*LambdaConfig) 
 				return ok
 			}
 			kept++
-			return kept < keepCount
+			return kept <= keepCount
 		})
 		for _, v := range scanVersions {
 			if err := s.scanLambdaFunctionArn(ctx, *v.FunctionArn, aliases[*v.Version]...); err != nil {


### PR DESCRIPTION
The "keep_aliase" attribute is obsoleted.

All aliased versions should be kept always because the versions could be invoked.

For backward compatibility, if "keep_aliase" (it is typo...) defined in the config file, puts an warning message.