### PR TITLE
bump Go 1.23

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,8 +5,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.21'
           - '1.22'
+          - '1.23'
     name: Build
     runs-on: ubuntu-latest
 

--- a/.github/workflows/tagpr-release.yml
+++ b/.github/workflows/tagpr-release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.23"
         if: ${{ steps.tagpr.outputs.tag != '' || github.event_name == 'workflow_dispatch' }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
This pull request updates the Go version used in the GitHub workflows to ensure compatibility with the latest Go release.

Updates to Go version:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL8-R9): Updated the Go version from `1.22` to `1.23` in the build job configuration.
* [`.github/workflows/tagpr-release.yml`](diffhunk://#diff-a39f58facc3a7d89120fe3c7fe9bac609d58e4fcfd7c0b843af6b59b258783c8L34-R34): Updated the Go version from `1.22` to `1.23` in the release job configuration.