### PR TITLE
Add external command support for custom image discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ task_definitions:
 lambda_functions:
   - name: "*"
     keep_count: 3
+external_commands:
+  - command: ["path/to/command", "arg1", "arg2"]
+    timeout: 30s
+    env:
+      AWS_REGION: "us-west-2"
 repositories:
   - name_pattern: "prod/*"
     expires: 90days
@@ -191,6 +196,37 @@ An example output is here.
 See also
 - [Under the hood: Lazy Loading Container Images with Seekable OCI and AWS Fargate](https://aws.amazon.com/jp/blogs/containers/under-the-hood-lazy-loading-container-images-with-seekable-oci-and-aws-fargate/)
 - [AWS Fargate Enables Faster Container Startup using Seekable OCI](https://aws.amazon.com/jp/blogs/aws/aws-fargate-enables-faster-container-startup-using-seekable-oci/)
+
+### External Commands
+
+`ecrm` allows you to run external commands during the scan and delete process.
+
+You can use external commands to integrate with other systems or platforms that `ecrm` does not natively support.
+
+For example, if you have workloads running on AWS AppRunner or Amazon EKS or etc., you can create a script that fetches the image URIs used by those services and outputs them in the required JSON format.
+
+```yaml
+external_commands:
+  - command: ["path/to/command", "arg1", "arg2"]
+    timeout: 30s
+    env:
+      AWS_REGION: "us-west-2"
+    dir: "/path/to/working/directory"
+```
+
+The command will output a JSON array of image URIs to STDOUT. `ecrm` will read the output and include the image URIs in its scan results to avoid deleting them.
+
+The format of the output required is a simple JSON array of image URIs.
+
+```json
+[
+  "012345678901.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar:latest",
+  "012345678901.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar@sha256:abcdef1234567890..."
+]
+```
+
+#### Use-case of External Commands
+
 
 ### Multi accounts / regions support.
 

--- a/config.go
+++ b/config.go
@@ -20,10 +20,11 @@ var (
 )
 
 type Config struct {
-	Clusters        []*ClusterConfig    `yaml:"clusters"`
-	TaskDefinitions []*TaskdefConfig    `yaml:"task_definitions"`
-	LambdaFunctions []*LambdaConfig     `yaml:"lambda_functions"`
-	Repositories    []*RepositoryConfig `yaml:"repositories"`
+	Clusters         []*ClusterConfig    `yaml:"clusters"`
+	TaskDefinitions  []*TaskdefConfig    `yaml:"task_definitions"`
+	LambdaFunctions  []*LambdaConfig     `yaml:"lambda_functions"`
+	ExternalCommands []*ExternalCommand  `yaml:"external_commands"`
+	Repositories     []*RepositoryConfig `yaml:"repositories"`
 }
 
 func (c *Config) Validate() error {

--- a/external.go
+++ b/external.go
@@ -1,0 +1,60 @@
+package ecrm
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type ExternalCommand struct {
+	Command []string          `json:"command"`
+	Env     map[string]string `json:"env,omitempty"`
+	Dir     string            `json:"dir,omitempty"`
+	Timeout time.Duration     `json:"timeout,omitempty"`
+}
+
+func (s *Scanner) scanExternalCommands(ctx context.Context, commands []*ExternalCommand) error {
+	for _, ext := range commands {
+		b, err := ext.Run(ctx)
+		if err != nil {
+			return err
+		}
+		imgs := make(Images)
+		src := "external_command: " + strings.Join(ext.Command, " ")
+		if err := imgs.LoadExternalJSON(src, b); err != nil {
+			return err
+		}
+		s.Images.Merge(imgs)
+	}
+	return nil
+}
+
+func (ext *ExternalCommand) Run(ctx context.Context) ([]byte, error) {
+	log.Printf("[info] scanning by external command: %v", ext.Command)
+	var cancel context.CancelFunc
+	if ext.Timeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, ext.Timeout)
+		defer cancel()
+	}
+	cmd := exec.CommandContext(ctx, ext.Command[0], ext.Command[1:]...)
+	cmd.Env = os.Environ()
+	for k, v := range ext.Env {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
+	}
+	buf := &bytes.Buffer{}
+	cmd.Stdout = buf
+	cmd.Stderr = os.Stderr
+	cmd.WaitDelay = 5 * time.Second // SIGKILL after 5 seconds of SIGTERM
+	if ext.Dir != "" {
+		cmd.Dir = ext.Dir
+	}
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to run external command %v: %w", ext.Command, err)
+	}
+	return buf.Bytes(), nil
+}

--- a/external.go
+++ b/external.go
@@ -26,7 +26,7 @@ func (s *Scanner) scanExternalCommands(ctx context.Context, commands []*External
 		}
 		imgs := make(Images)
 		src := "external_command: " + strings.Join(ext.Command, " ")
-		if err := imgs.LoadExternalJSON(src, b); err != nil {
+		if err := imgs.LoadJSON(src, b); err != nil {
 			return err
 		}
 		s.Images.Merge(imgs)

--- a/external_test.go
+++ b/external_test.go
@@ -1,0 +1,50 @@
+package ecrm_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/fujiwara/ecrm"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestExternalCommand(t *testing.T) {
+	ext := &ecrm.ExternalCommand{
+		Command: []string{"sh", "-c", `printf '["foobar:%s"]' "${TAG}"`},
+		Env:     map[string]string{"TAG": "deadbeef"},
+	}
+	b, err := ext.Run(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmp.Diff(string(b), `["foobar:deadbeef"]`) != "" {
+		t.Errorf("unexpected output: %s", b)
+	}
+}
+
+func TestExternalCommandDir(t *testing.T) {
+	ext := &ecrm.ExternalCommand{
+		Command: []string{"sh", "-c", "pwd"},
+		Dir:     "/",
+	}
+	b, err := ext.Run(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmp.Diff(string(bytes.TrimSpace(b)), "/") != "" {
+		t.Errorf("unexpected output: %s", b)
+	}
+}
+
+func TestExternalCommandTimeout(t *testing.T) {
+	ext := &ecrm.ExternalCommand{
+		Command: []string{"sh", "-c", "sleep 0.3"},
+		Timeout: time.Millisecond * 100,
+	}
+	_, err := ext.Run(t.Context())
+	if err == nil {
+		t.Fatal("should be errored by timeout")
+	}
+	t.Log(err)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fujiwara/ecrm
 
-go 1.21
+go 1.24
 
 toolchain go1.25.1
 

--- a/images.go
+++ b/images.go
@@ -69,23 +69,14 @@ func (i Images) Print(w io.Writer) error {
 }
 
 func (i Images) LoadFile(filename string) error {
-	f, err := os.Open(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return fmt.Errorf("failed to open file: %w", err)
 	}
-	defer f.Close()
-	in := []string{}
-	if err := json.NewDecoder(f).Decode(&in); err != nil {
-		return fmt.Errorf("failed to decode images: %w", err)
-	}
-	for _, u := range in {
-		log.Println("[debug] ImageUri", u, "src", filename)
-		i[ImageURI(u)] = newSet(filename)
-	}
-	return nil
+	return i.LoadJSON(filename, b)
 }
 
-func (i Images) LoadExternalJSON(src string, b []byte) error {
+func (i Images) LoadJSON(src string, b []byte) error {
 	in := []string{}
 	if err := json.Unmarshal(b, &in); err != nil {
 		return fmt.Errorf("failed to decode images: %w", err)

--- a/images.go
+++ b/images.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"sort"
 	"strings"
@@ -78,7 +79,20 @@ func (i Images) LoadFile(filename string) error {
 		return fmt.Errorf("failed to decode images: %w", err)
 	}
 	for _, u := range in {
+		log.Println("[debug] ImageUri", u, "src", filename)
 		i[ImageURI(u)] = newSet(filename)
+	}
+	return nil
+}
+
+func (i Images) LoadExternalJSON(src string, b []byte) error {
+	in := []string{}
+	if err := json.Unmarshal(b, &in); err != nil {
+		return fmt.Errorf("failed to decode images: %w", err)
+	}
+	for _, u := range in {
+		log.Println("[debug] ImageUri", u, "src", src)
+		i[ImageURI(u)] = newSet(src)
 	}
 	return nil
 }

--- a/images_test.go
+++ b/images_test.go
@@ -3,6 +3,7 @@ package ecrm_test
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/fujiwara/ecrm"
@@ -87,6 +88,25 @@ func TestLoadImages(t *testing.T) {
 	images.Add("9876543210987.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar:fe668fb9", "baz")
 	images.Add("0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar:fe668fb9", "baz")
 	err := images.LoadFile("testdata/images.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(images) != 4 {
+		t.Errorf("unexpected images: %d", len(images))
+	}
+	t.Logf("images: %#v", images)
+}
+
+func TestLoadExternalJSON(t *testing.T) {
+	images := make(ecrm.Images)
+	images.Add("9876543210987.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar:fe668fb9", "baz")
+	images.Add("0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar:fe668fb9", "baz")
+	src := "testdata/images.json"
+	b, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = images.LoadExternalJSON(src, b)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/images_test.go
+++ b/images_test.go
@@ -97,7 +97,7 @@ func TestLoadImages(t *testing.T) {
 	t.Logf("images: %#v", images)
 }
 
-func TestLoadExternalJSON(t *testing.T) {
+func TestLoadJSON(t *testing.T) {
 	images := make(ecrm.Images)
 	images.Add("9876543210987.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar:fe668fb9", "baz")
 	images.Add("0123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar:fe668fb9", "baz")
@@ -106,7 +106,7 @@ func TestLoadExternalJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = images.LoadExternalJSON(src, b)
+	err = images.LoadJSON(src, b)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scanner.go
+++ b/scanner.go
@@ -52,6 +52,10 @@ func (s *Scanner) Scan(ctx context.Context, c *Config) error {
 		return err
 	}
 
+	if err := s.scanExternalCommands(ctx, c.ExternalCommands); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This allows users to integrate with services not natively supported by ecrm (e.g., AppRunner, EKS) by executing external commands that output image URIs in JSON format. The discovered images are excluded from deletion.

refs https://github.com/fujiwara/ecrm/pull/94

### External Commands

`ecrm` allows you to run external commands during the `plan` and `delete` process.

You can use external commands to integrate with other systems or platforms that `ecrm` does not natively support.

For example, if you have workloads running on AWS AppRunner or Amazon EKS or etc., you can create a script that fetches the image URIs used by those services and outputs them in the required JSON format.

```yaml
external_commands:
  - command: ["path/to/command", "arg1", "arg2"]
    timeout: 30s
    env:
      AWS_REGION: "us-west-2"
    dir: "/path/to/working/directory"
```

The command will output a JSON array of image URIs to STDOUT. `ecrm` will read the output and include the image URIs in its scan results to avoid deleting them.

The format of the output required is a simple JSON array of image URIs.

```json
[
  "012345678901.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar:latest",
  "012345678901.dkr.ecr.ap-northeast-1.amazonaws.com/foo/bar@sha256:abcdef1234567890..."
]
```
