### PR TITLE
Protect constituent images referenced by kept image indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,13 +210,15 @@ Flags:
 
 ### Support to image indexes and soci indexes.
 
-ecrm supports image indexes and soci (Seekable OCI) indexes. ecrm deletes these images that are related to expired images safely.
+ecrm supports image indexes and soci (Seekable OCI) indexes. ecrm handles these images safely during the plan and delete process.
 
 1. Scans ECR repositories.
    - Detect image type (Image, Image index, Soci index).
-2. Find expired images.
-3. Find expired image indexes related to expired images by the image tag (sha256-{digest of image}).
-4. Find soci indexes related to expired image indexes using ECR BatchGetImage API for expired images.
+2. Determine which image indexes should be kept (by all standard criteria: in-use references, tag patterns, expiry, keep_count).
+3. Protect constituent platform-specific images (e.g. linux/amd64, linux/arm64) referenced by kept image indexes, so they are not deleted even if they would otherwise be expired.
+4. Find expired images (excluding protected constituent images).
+5. Find expired image indexes.
+6. Find soci indexes related to expired image indexes using ECR BatchGetImage API.
 
 An example output is here.
 

--- a/export_test.go
+++ b/export_test.go
@@ -1,5 +1,6 @@
 package ecrm
 
 var (
-	ParseTaskdefArn = parseTaskdefArn
+	ParseTaskdefArn  = parseTaskdefArn
+	IsKeptImageIndex = isKeptImageIndex
 )

--- a/generate.go
+++ b/generate.go
@@ -149,7 +149,7 @@ func (g *Generator) generateLambdaConfig(ctx context.Context, config *Config) er
 	}
 	for _, name := range lambdaNames.members() {
 		cfg := LambdaConfig{
-			KeepCount:   int64(DefaultKeepCount),
+			KeepCount: int64(DefaultKeepCount),
 		}
 		if strings.Contains(name, "*") {
 			cfg.NamePattern = name

--- a/planner.go
+++ b/planner.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -33,9 +34,7 @@ type DeletableImageIDs map[RepositoryName][]ecrTypes.ImageIdentifier
 
 func (d DeletableImageIDs) RepositoryNames() []RepositoryName {
 	names := lo.Keys(d)
-	sort.Slice(names, func(i, j int) bool {
-		return names[i] < names[j]
-	})
+	slices.Sort(names)
 	return names
 }
 
@@ -89,6 +88,16 @@ func (p *Planner) unusedImageIdentifiers(ctx context.Context, repo RepositoryNam
 		return nil, sums, err
 	}
 	log.Printf("[info] %s has %d images, %d image indexes, %d soci indexes", repo, len(images), len(imageIndexes), len(sociIndexes))
+
+	// Pre-compute which image indexes should be kept, then register their constituent
+	// platform-specific images (e.g. linux/amd64, linux/arm64) into keepImages.
+	// This must happen before evaluating individual images so that constituents of
+	// a kept image index are not incorrectly marked as expired.
+	keptIndexDigests, keptIndexIDs := p.computeKeptImageIndexIDs(rc, keepImages, imageIndexes)
+	if err := p.addConstituentImagesToKeep(ctx, repo, keptIndexIDs, keepImages); err != nil {
+		return nil, sums, fmt.Errorf("failed to protect constituent images of kept image indexes: %w", err)
+	}
+
 	expiredIds := make([]ecrTypes.ImageIdentifier, 0)
 	expiredImageIndexes := newSet()
 	var keepCount int64
@@ -146,17 +155,17 @@ IMAGE:
 		}
 	}
 
-IMAGE_INDEX:
 	for _, d := range imageIndexes {
 		log.Printf("[debug] is an image index %s", *d.ImageDigest)
 		sums.Add(d)
+		if keptIndexDigests.contains(*d.ImageDigest) {
+			continue
+		}
+		log.Printf("[notice] image index %s@%s is expired %s", repo, *d.ImageDigest, d.ImagePushedAt.Format(time.RFC3339))
+		sums.Expire(d)
+		expiredIds = append(expiredIds, ecrTypes.ImageIdentifier{ImageDigest: d.ImageDigest})
 		for _, tag := range d.ImageTags {
-			if expiredImageIndexes.contains(tag) {
-				log.Printf("[notice] %s:%s is expired (image index)", repo, tag)
-				sums.Expire(d)
-				expiredIds = append(expiredIds, ecrTypes.ImageIdentifier{ImageDigest: d.ImageDigest})
-				continue IMAGE_INDEX
-			}
+			expiredImageIndexes.add(tag)
 		}
 	}
 
@@ -218,6 +227,109 @@ func (p *Planner) listImageDetails(ctx context.Context, repo RepositoryName) ([]
 		return sociIndexes[i].ImagePushedAt.After(*sociIndexes[j].ImagePushedAt)
 	})
 	return images, imageIndexes, sociIndexes, foundTags, nil
+}
+
+// computeKeptImageIndexIDs determines which image indexes should be kept by applying
+// all standard retention criteria (in-use references, tag patterns, expiry, keep_count).
+// Returns the set of kept digests (for quick lookup) and their identifiers (for BatchGetImage).
+func (p *Planner) computeKeptImageIndexIDs(rc *RepositoryConfig, keepImages Images, imageIndexes []ecrTypes.ImageDetail) (set, []ecrTypes.ImageIdentifier) {
+	keptDigests := newSet()
+	keptIDs := make([]ecrTypes.ImageIdentifier, 0)
+	var keepCount int64
+
+	for _, d := range imageIndexes {
+		keep := false
+		if isKeptImageIndex(d, p.region, keepImages) {
+			keep = true
+		} else {
+			tagMatched := slices.ContainsFunc(d.ImageTags, rc.MatchTag)
+			if tagMatched {
+				keep = true
+			} else if !rc.IsExpired(*d.ImagePushedAt) {
+				keep = true
+			} else {
+				_, tagged := imageTag(d)
+				if tagged {
+					keepCount++
+					if keepCount <= rc.KeepCount {
+						keep = true
+					}
+				}
+			}
+		}
+		if keep {
+			keptDigests.add(*d.ImageDigest)
+			keptIDs = append(keptIDs, ecrTypes.ImageIdentifier{ImageDigest: d.ImageDigest})
+		}
+	}
+	return keptDigests, keptIDs
+}
+
+// addConstituentImagesToKeep fetches manifests of kept image indexes and adds every
+// constituent platform-specific image digest to keepImages so they are not deleted.
+func (p *Planner) addConstituentImagesToKeep(ctx context.Context, repo RepositoryName, keptIndexIDs []ecrTypes.ImageIdentifier, keepImages Images) error {
+	if len(keptIndexIDs) == 0 {
+		return nil
+	}
+
+	for _, c := range lo.Chunk(keptIndexIDs, batchGetImageLimit) {
+		res, err := p.ecr.BatchGetImage(ctx, &ecr.BatchGetImageInput{
+			ImageIds:       c,
+			RepositoryName: aws.String(string(repo)),
+			AcceptedMediaTypes: []string{
+				string(ociTypes.OCIImageIndex),
+				string(ociTypes.DockerManifestList),
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to batch get image index manifest: %w", err)
+		}
+		if len(res.Failures) > 0 {
+			for _, f := range res.Failures {
+				log.Printf("[warn] failed to get image index manifest: %s %s", aws.ToString(f.ImageId.ImageDigest), f.FailureCode)
+			}
+			return fmt.Errorf("failed to get %d image index manifest(s), aborting to avoid deleting constituent images", len(res.Failures))
+		}
+		for _, img := range res.Images {
+			if img.ImageManifest == nil {
+				continue
+			}
+			var m oci.IndexManifest
+			if err := json.Unmarshal([]byte(*img.ImageManifest), &m); err != nil {
+				log.Printf("[warn] failed to parse image index manifest for %s: %s", aws.ToString(img.ImageId.ImageDigest), err)
+				continue
+			}
+			for _, d := range m.Manifests {
+				if d.ArtifactType == MediaTypeSociIndex {
+					continue
+				}
+				constituentURI := ImageURI(fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s@%s",
+					aws.ToString(img.RegistryId), p.region, aws.ToString(img.RepositoryName), d.Digest.String()))
+				if keepImages.Add(constituentURI, "image_index_constituent") {
+					log.Printf("[info] constituent image %s is added to keep list by parent image index", constituentURI)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// isKeptImageIndex reports whether an image index is directly referenced in keepImages
+// (by digest or by tag), meaning it is in use by ECS tasks / task definitions / lambda functions.
+func isKeptImageIndex(d ecrTypes.ImageDetail, region string, keepImages Images) bool {
+	imageURISha256 := ImageURI(fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s@%s",
+		aws.ToString(d.RegistryId), region, aws.ToString(d.RepositoryName), aws.ToString(d.ImageDigest)))
+	if keepImages.Contains(imageURISha256) {
+		return true
+	}
+	for _, tag := range d.ImageTags {
+		imageURI := ImageURI(fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:%s",
+			aws.ToString(d.RegistryId), region, aws.ToString(d.RepositoryName), tag))
+		if keepImages.Contains(imageURI) {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Planner) findSociIndex(ctx context.Context, repo RepositoryName, imageTags []string) ([]ecrTypes.ImageIdentifier, error) {

--- a/planner_test.go
+++ b/planner_test.go
@@ -1,0 +1,86 @@
+package ecrm_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ecrTypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
+	"github.com/fujiwara/ecrm"
+)
+
+func TestIsKeptImageIndex(t *testing.T) {
+	region := "ap-northeast-1"
+	registryID := "012345678901"
+	repoName := "my-service"
+
+	tests := []struct {
+		name       string
+		detail     ecrTypes.ImageDetail
+		keepImages ecrm.Images
+		want       bool
+	}{
+		{
+			name: "kept by digest",
+			detail: ecrTypes.ImageDetail{
+				RegistryId:     aws.String(registryID),
+				RepositoryName: aws.String(repoName),
+				ImageDigest:    aws.String("sha256:aaa"),
+			},
+			keepImages: func() ecrm.Images {
+				m := make(ecrm.Images)
+				m.Add("012345678901.dkr.ecr.ap-northeast-1.amazonaws.com/my-service@sha256:aaa", "taskdef")
+				return m
+			}(),
+			want: true,
+		},
+		{
+			name: "kept by tag",
+			detail: ecrTypes.ImageDetail{
+				RegistryId:     aws.String(registryID),
+				RepositoryName: aws.String(repoName),
+				ImageDigest:    aws.String("sha256:bbb"),
+				ImageTags:      []string{"v1.0"},
+			},
+			keepImages: func() ecrm.Images {
+				m := make(ecrm.Images)
+				m.Add("012345678901.dkr.ecr.ap-northeast-1.amazonaws.com/my-service:v1.0", "taskdef")
+				return m
+			}(),
+			want: true,
+		},
+		{
+			name: "not kept",
+			detail: ecrTypes.ImageDetail{
+				RegistryId:     aws.String(registryID),
+				RepositoryName: aws.String(repoName),
+				ImageDigest:    aws.String("sha256:ccc"),
+				ImageTags:      []string{"old"},
+			},
+			keepImages: func() ecrm.Images {
+				m := make(ecrm.Images)
+				m.Add("012345678901.dkr.ecr.ap-northeast-1.amazonaws.com/other-service:latest", "taskdef")
+				return m
+			}(),
+			want: false,
+		},
+		{
+			name: "not kept with empty keepImages",
+			detail: ecrTypes.ImageDetail{
+				RegistryId:     aws.String(registryID),
+				RepositoryName: aws.String(repoName),
+				ImageDigest:    aws.String("sha256:ddd"),
+			},
+			keepImages: make(ecrm.Images),
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ecrm.IsKeptImageIndex(tt.detail, region, tt.keepImages)
+			if got != tt.want {
+				t.Errorf("IsKeptImageIndex() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- When an image index (multi-arch manifest list) is kept, its constituent platform-specific images (e.g. linux/amd64, linux/arm64) are now also protected from deletion
- Before evaluating individual images, pre-compute which image indexes are kept and fetch their manifests to register constituent images into the keep list
- Refactor the IMAGE_INDEX loop to use the pre-computed kept digest set instead of the previous tag-based approach
- Use image index media types (OCIImageIndex, DockerManifestList) for BatchGetImage
- Treat BatchGetImage failures as errors to prevent silently missing constituent images
- Record expired image index tags for SOCI index discovery

Fixes #123

Credit to https://github.com/7474/ecrm/pull/1 for the initial fix approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)